### PR TITLE
basic implementation of cached geometry

### DIFF
--- a/examples/cachedGeometry/index.html
+++ b/examples/cachedGeometry/index.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <script src="../build.js"></script>
+  </head>
+  <body>
+    <a-assets></a-assets>
+    <a-scene>
+      <a-entity geometry="primitive: sphere; radius: 1000"
+                material="color: #5F818A; shader: flat"
+                scale="1 1 -1"></a-entity>
+      <a-entity id="textObj"
+                text="text: Hello, World!"
+                material="color: #66E1B4"
+                position="0 -5 -20"></a-entity>
+    </a-scene>
+    <script src="switchText.js"></script>
+  </body>
+</html>

--- a/examples/cachedGeometry/switchText.js
+++ b/examples/cachedGeometry/switchText.js
@@ -1,0 +1,18 @@
+var strings = [
+  'Bacon ipsum dolor amet picanha prosciutto cow, andouille doner ribeye shankle jowl tri-tip cupim alcatra frankfurter kevin venison landjaeger. Meatloaf pork loin pig tongue, hamburger pastrami pork sirloin filet mignon. Shankle shank rump doner bacon salami meatball hamburger tail chicken swine. Chicken tongue picanha venison jowl. Shankle tail hamburger ribeye, filet mignon fatback pork chop.',
+  'Pork salami tri-tip andouille, shankle meatball ham shank kevin tail prosciutto turkey. Ham chuck strip steak, alcatra prosciutto beef biltong. Pig pork kielbasa strip steak frankfurter bresaola kevin ribeye ham hamburger. Picanha capicola fatback chicken meatball. Tenderloin shankle beef ribs pancetta tail, turducken venison meatball short ribs jerky doner.',
+  'Chuck corned beef frankfurter pork loin, tenderloin shank filet mignon salami tail jerky pancetta sausage jowl. Porchetta flank meatball bresaola, salami fatback pork belly beef ribs short ribs boudin filet mignon chicken. Andouille chuck beef tenderloin, leberkas ham frankfurter turkey short loin short ribs venison cow. Ribeye pork chop drumstick kielbasa spare ribs. Cupim meatball pork belly bresaola prosciutto. Shoulder pancetta turducken hamburger, pork salami pork chop beef biltong beef ribs ground round.',
+  'Boudin alcatra shankle ball tip tenderloin cupim venison kevin. Salami biltong pork chop ham hock ball tip, prosciutto sausage hamburger pastrami chicken pork loin pig drumstick. Pork belly shankle hamburger, turducken alcatra jerky venison sirloin swine strip steak drumstick short loin pancetta filet mignon chuck. Corned beef pastrami salami, strip steak shank prosciutto meatloaf kevin bacon fatback chuck ball tip filet mignon. Pastrami leberkas frankfurter short ribs, ham hock salami capicola bresaola sirloin pork kielbasa pork loin ground round strip steak. Turkey alcatra pastrami, strip steak ball tip andouille doner shoulder salami.',
+  'all strings are now cached. The delay shall go away'
+];
+
+var i = 0;
+
+function switchText () {
+  var el = document.getElementById('textObj');
+  if(el) {
+    el.setAttribute('text', 'text: ' + strings[i++ % strings.length])
+  }
+}
+
+setInterval(switchText, 500);

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 require('./lib/FontUtils');
 require('./lib/TextGeometry');
 require('./lib/helvetiker_regular.typeface');
+var hash = require('object-hash');
 
 module.exports.component = {
   schema: {
@@ -19,12 +20,19 @@ module.exports.component = {
     weight: { default: 'normal', oneOf: [ 'normal', 'bold' ] }
   },
 
+  init: function () {
+    window.aframeTextGeometryCache = {};
+  },
+
   /**
    * Called when component is attached and when component data changes.
    * Generally modifies the entity based on the data.
    */
   update: function (oldData) {
-    this.el.getOrCreateObject3D('mesh', THREE.Mesh).geometry = getTextGeometry(this.data);
+    var dataKey = hash(this.data);
+    var geometry = aframeTextGeometryCache[dataKey] || getTextGeometry(this.data);
+    aframeTextGeometryCache[dataKey] = geometry;
+    this.el.object3D.geometry = geometry;
   }
 };
 


### PR DESCRIPTION
This is not per-letter which is a bit more challenging and either has to happen in the guts of `THREE.TextGeometry` or that needs to be reimplemented. The challenge is in preserving letter spacing.

Here is a simple implementation which can at least be used with a dictionary of known strings. If one were to create and immediately remove one aframe-text-component per word, this would effectively preload all the geometry needed. An example is provided.